### PR TITLE
Add PyData NYC/Miami 2022 + link to timezonefinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ To add or update a deadline:
 - Fork the repository
 - Update `_data/conferences.yml`
 - Make sure it has the `title`, `year`, `id`, `link`, `cfp`, `timezone`, `date`, `place`, `sub` attributes
-    + See available timezone strings [here](https://momentjs.com/timezone/).
-    + The [timezonefinder](https://github.com/jannikmi/timezonefinder) Python library provides a [online web app](https://timezonefinder.michelfe.it/)
-      for looking up the corresponding timezone for any given coordinates.
+    + This [online web app](https://timezonefinder.michelfe.it/) makes it easy to find timezones – just click! 
+      (It's based on the [timezonefinder](https://github.com/jannikmi/timezonefinder) Python library.)
+    + Alternatively, see available timezone strings [here](https://momentjs.com/timezone/).
 - Optionally add a `note`
 - Example:
     ```yaml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ To add or update a deadline:
 - Update `_data/conferences.yml`
 - Make sure it has the `title`, `year`, `id`, `link`, `cfp`, `timezone`, `date`, `place`, `sub` attributes
     + See available timezone strings [here](https://momentjs.com/timezone/).
+    + The [timezonefinder](https://github.com/jannikmi/timezonefinder) Python library provides a [online web app](https://timezonefinder.michelfe.it/)
+      for looking up the corresponding timezone for any given coordinates.
 - Optionally add a `note`
 - Example:
     ```yaml

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -422,3 +422,27 @@
   start: 2022-07-11
   end: 2022-07-18
   sub: PY
+
+- title: Pydata Miama
+  year: 2022
+  id: pydataMiama22
+  link: https://pydata.org/miami2022/
+  place: Miama, Florida, USA
+  cfp: '2022-08-08 23:59:00'
+  date: September 22, 2022
+  start: 2022-09-22
+  end: 2022-09-22
+  timezone: America/New_York
+  sub: PYDATA
+
+- title: Pydata NYC
+  year: 2022
+  id: pydataNYC22
+  link: https://pydata.org/nyc2022/
+  place: New York, NY, USA
+  cfp: '2022-08-24 23:59:00'
+  date: November 09 – 11, 2022
+  start: 2022-11-09
+  end: 2022-11-11
+  timezone: America/New_York
+  sub: PYDATA


### PR DESCRIPTION
- Add https://pydata.org/miami2022/
- Add https://pydata.org/nyc2022/
- I got confused by the official timezone for Miami being `America/New_York` so wanted to double check, found https://github.com/jannikmi/timezonefinder and their web app https://timezonefinder.michelfe.it/gui/ to be very nice for this so have added into README