### PR TITLE
PyData London 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -765,7 +765,7 @@
   start: 2024-06-14
   end: 2024-06-16
   twitter: PyDataLondon
-  sub: PY,PYDATA
+  sub: PYDATA
   location:
     latitude: 51.51072
     longitude: -0.07655

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -754,3 +754,18 @@
   location:
     latitude: 52.5170365
     longitude: 13.3888599
+
+- title: PyData London
+  year: 2024
+  link: https://pydata.org/london2024/
+  cfp: TBA
+  timezone: Europe/London
+  place: London, United Kingdom
+  date: June 14 - 16, 2024
+  start: 2024-06-14
+  end: 2024-06-16
+  twitter: PyDataLondon
+  sub: PY,PYDATA
+  location:
+    latitude: 51.51072
+    longitude: -0.07655


### PR DESCRIPTION
Website will launch 14 Sep 2023.
CfP will open 14th Feb 2024.
CfP will close 24th Mar 2024.