### PR TITLE
conf: PyData Paris 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -168,6 +168,17 @@
     latitude: 53.2190652
     longitude: 6.5680077
 
+- conference: PyData Paris
+  year: 2025
+  link: https://pydata.org/paris2025
+  cfp_link: https://pydata.org/paris2025/cfp
+  cfp: '2025-04-13 23:59:00'
+  timezone: Europe/Paris
+  place: Paris, France
+  start: 2025-09-30
+  end: 2025-10-02
+  sub: DATA
+
 - conference: PyCon Colombia
   year: 2025
   link: https://2025.pycon.co/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -181,6 +181,7 @@
   sponsor: https://pydata.org/paris2025/sponsorship-opportunites#tiers
   mastodon: https://mastodon.social/@PyDataParis
   bluesky: https://bsky.app/profile/pydataparis.bsky.social
+  location:
   - title: PyData Paris 2025
     latitude: 48.89591923094818
     longitude: 2.388543327766867

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -178,6 +178,12 @@
   start: 2025-09-30
   end: 2025-10-02
   sub: DATA
+  sponsor: https://pydata.org/paris2025/sponsorship-opportunites#tiers
+  mastodon: https://mastodon.social/@PyDataParis
+  bluesky: https://bsky.app/profile/pydataparis.bsky.social
+  - title: PyData Paris 2025
+    latitude: 48.89591923094818
+    longitude: 2.388543327766867
 
 - conference: PyCon Colombia
   year: 2025


### PR DESCRIPTION
I also included an entry for the `bluesky` key in case it can be used in the future.

If it's invalid, I can update the PR to remove it.