### PR TITLE
Update conferences.yml

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -4,7 +4,7 @@
   year: 2025
   link: https://pydata.org/global2025/
   cfp_link: https://cfp.pydata.org/pydataglobal2025/cfp
-  cfp: '2025-10-28 23:59:00'
+  cfp: '2025-08-06 23:59:00'
   place: Online
   start: 2025-12-09
   end: 2025-12-11


### PR DESCRIPTION
PyData Global 2025 seemed to have closed its CFP on August 6, 2025, as mentioned here: https://cfp.pydata.org/pydataglobal2025/cfp