### PR TITLE
feat: add conference sort before commit in update workflow

### DIFF
--- a/.github/workflows/check-conference-update.yml
+++ b/.github/workflows/check-conference-update.yml
@@ -738,6 +738,14 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Pixi
+        if: steps.check_changes.outputs.changed == 'true'
+        uses: prefix-dev/setup-pixi@v0.9.2
+
+      - name: Sort conferences
+        if: steps.check_changes.outputs.changed == 'true'
+        run: pixi run sort
+
       - name: Commit and push
         if: steps.check_changes.outputs.changed == 'true'
         id: commit
@@ -964,19 +972,31 @@ jobs:
             --max-turns 5
             --allowedTools Read,Edit,Grep,Glob
 
-      - name: Check, commit, push
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if ! diff -q _data/conferences.yml /tmp/conferences_before.yml > /dev/null 2>&1; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Pixi
+        if: steps.check_changes.outputs.changed == 'true'
+        uses: prefix-dev/setup-pixi@v0.9.2
+
+      - name: Sort conferences
+        if: steps.check_changes.outputs.changed == 'true'
+        run: pixi run sort
+
+      - name: Commit and push
+        if: steps.check_changes.outputs.changed == 'true'
         id: commit
         env:
           CONF_NAME: ${{ needs.zone-check.outputs.conference }}
           CONF_URL: ${{ needs.zone-check.outputs.url }}
           DETECTED_YEAR: ${{ needs.triage.outputs.detected_year }}
         run: |
-          if diff -q _data/conferences.yml /tmp/conferences_before.yml > /dev/null 2>&1; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "changed=true" >> $GITHUB_OUTPUT
           git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
           git add _data/conferences.yml
           git commit -m "conf: ${CONF_NAME} ${DETECTED_YEAR} 🆕" -m "New year detected" -m "Source: ${CONF_URL}"
@@ -984,7 +1004,7 @@ jobs:
           echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Create or update PR
-        if: steps.commit.outputs.changed == 'true'
+        if: steps.check_changes.outputs.changed == 'true'
         uses: actions/github-script@v7
         env:
           UPDATE_BRANCH: ${{ env.UPDATE_BRANCH }}
@@ -1039,7 +1059,7 @@ jobs:
         env:
           CONF_NAME: ${{ needs.zone-check.outputs.conference }}
           YEAR: ${{ needs.triage.outputs.detected_year }}
-          CHANGED: ${{ steps.commit.outputs.changed }}
+          CHANGED: ${{ steps.check_changes.outputs.changed }}
         run: |
           echo "## 🆕 New Year: $CONF_NAME $YEAR" >> $GITHUB_STEP_SUMMARY
           echo "Status: $([[ '$CHANGED' == 'true' ]] && echo '✅ Created' || echo '⚠️ No changes')" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Run `pixi run sort` before committing in both the analyze-update and new-year-scraper jobs to ensure conference data is consistently sorted when automated updates are made.