### PR TITLE
fix: include .conf-title-small in mobile test selector

### DIFF
--- a/tests/e2e/specs/search-functionality.spec.js
+++ b/tests/e2e/specs/search-functionality.spec.js
@@ -160,7 +160,8 @@ test.describe('Search Functionality', () => {
 
       if (await firstResult.isVisible()) {
         // Check for essential conference information
-        const title = firstResult.locator('.conf-title, .conference-title, h3, h4');
+        // On mobile viewports, .conf-title is hidden and .conf-title-small is shown instead
+        const title = firstResult.locator('.conf-title, .conf-title-small, .conference-title, h3, h4');
         await expect(title).toBeVisible();
 
         // Check for deadline or date


### PR DESCRIPTION
On mobile viewports (≤576px), .conf-title is hidden via CSS and .conf-title-small is displayed instead. The test was only looking for .conf-title, causing it to fail on mobile-chrome because the element exists but is hidden.