### PR TITLE
fix: grant write permission for extension checker dispatch events

### DIFF
--- a/.github/workflows/scheduled-extension-checker.yml
+++ b/.github/workflows/scheduled-extension-checker.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: write
     strategy:
       matrix:
         conference: ${{ fromJson(needs.find-closing-cfps.outputs.conferences) }}


### PR DESCRIPTION
The trigger-checks job needs contents: write permission to create repository dispatch events via gh api. The previous contents: read permission caused HTTP 403 "Resource not accessible by integration".