### PR TITLE
fix: skip location visibility check on mobile viewports

### DIFF
--- a/tests/e2e/specs/search-functionality.spec.js
+++ b/tests/e2e/specs/search-functionality.spec.js
@@ -148,7 +148,7 @@ test.describe('Search Functionality', () => {
   });
 
   test.describe('Search Results Display', () => {
-    test('should display conference details in results', async ({ page }) => {
+    test('should display conference details in results', async ({ page }, testInfo) => {
       const searchInput = await getVisibleSearchInput(page);
 
       // Search for conferences
@@ -173,10 +173,13 @@ test.describe('Search Functionality', () => {
           await expect(deadline.first()).toBeVisible();
         }
 
-        // Check for location
-        const location = firstResult.locator('.conf-place, .location, .place');
-        if (await location.count() > 0) {
-          await expect(location.first()).toBeVisible();
+        // Check for location (hidden on mobile viewports via CSS)
+        const isMobile = testInfo.project.name.includes('mobile');
+        if (!isMobile) {
+          const location = firstResult.locator('.conf-place, .location, .place');
+          if (await location.count() > 0) {
+            await expect(location.first()).toBeVisible();
+          }
         }
       }
     });


### PR DESCRIPTION
On mobile viewports (≤576px), .conf-place is hidden via CSS with display: none. The test was checking for location visibility on all viewports, causing it to fail on mobile-chrome because the element exists but is intentionally hidden by CSS design.

This fix mirrors the approach used for mobile-safari where we already handle .conf-title vs .conf-title-small differences.