### PR TITLE
fix(workflow): prevent all-contributors-cli from replacing existing contributions

### DIFF
--- a/.github/workflows/pr-sort.yml
+++ b/.github/workflows/pr-sort.yml
@@ -80,10 +80,18 @@ jobs:
         # Run sort command
         pixi run sort
 
-        # Add contributor if specified
+        # Add contributor if specified and not already in the list
+        # This check avoids a bug in all-contributors-cli (issue #371) where
+        # adding an existing contributor can replace their existing contributions
         if [[ -n "${{ steps.vars.outputs.contributor }}" ]]; then
-          pixi run install
-          pixi run add ${{ steps.vars.outputs.contributor }} conference
+          CONTRIBUTOR="${{ steps.vars.outputs.contributor }}"
+          if ! jq -e --arg login "$CONTRIBUTOR" '.contributors[] | select(.login == $login)' .all-contributorsrc > /dev/null 2>&1; then
+            echo "Adding new contributor: $CONTRIBUTOR"
+            pixi run install
+            pixi run add "$CONTRIBUTOR" conference
+          else
+            echo "Contributor $CONTRIBUTOR already exists, skipping to avoid contribution loss (all-contributors-cli bug #371)"
+          fi
         fi
 
         # Check if there are changes


### PR DESCRIPTION
Add a check to verify if a contributor already exists in .all-contributorsrc before running `all-contributors add`. This works around a bug in all-contributors-cli (issue #371) where adding an existing contributor with overlapping contribution types causes all their existing contributions to be replaced with just the new type.

The fix uses jq to check if the contributor's login already exists in the contributors array, and skips the add command if they do.