### PR TITLE
fix(merge): preserve country codes when iso3166 lookup fails

### DIFF
--- a/tests/test_csv_processing.py
+++ b/tests/test_csv_processing.py
@@ -410,18 +410,17 @@ class TestCountryCodePreservation:
         """
         # Create test data with place values (as they would come from the merge)
         places = [
-            "New York, USA",           # Common alias
-            "London, United Kingdom",   # Standard name
-            "Prague, Czechia",          # Known alias
-            "Atlantis, Narnia",         # Unknown - should be preserved
-            "Tokyo, Japan",             # Standard name
+            "New York, USA",  # Common alias
+            "London, United Kingdom",  # Standard name
+            "Prague, Czechia",  # Known alias
+            "Atlantis, Narnia",  # Unknown - should be preserved
+            "Tokyo, Japan",  # Standard name
         ]
 
         # Simulate the country extraction that happens in main() before write_csv
         # This is the code at lines 480-490 in import_python_organizers.py
         countries_from_places = [
-            import_python_organizers.get_country_alpha3(place.split(",")[-1].strip())
-            for place in places
+            import_python_organizers.get_country_alpha3(place.split(",")[-1].strip()) for place in places
         ]
 
         test_data = pd.DataFrame(

--- a/utils/import_python_organizers.py
+++ b/utils/import_python_organizers.py
@@ -482,12 +482,7 @@ def main(year: int | None = None, base: str = "") -> None:
     df_csv_output.loc[:, "Location"] = df_csv_output.place
     # Extract country from place (format: "City, Country") and convert to alpha3 code
     # Uses get_country_alpha3 which preserves original country name if lookup fails
-    df_csv_output.loc[:, "Country"] = (
-        df_csv_output.place.str.split(",")
-        .str[-1]
-        .str.strip()
-        .apply(get_country_alpha3)
-    )
+    df_csv_output.loc[:, "Country"] = df_csv_output.place.str.split(",").str[-1].str.strip().apply(get_country_alpha3)
 
     write_csv(df_csv_output, year, csv_location)
 


### PR DESCRIPTION
Previously, when a country name wasn't found in iso3166.countries_by_name, the code silently returned an empty string, causing country codes to be lost in the output CSV. This was particularly problematic for:

- Common aliases like "USA", "UK", "Czechia"
- Lesser-known country name variations
- Completely unknown locations

Changes:
- Add get_country_alpha3() helper with robust lookup strategy:
  1. Direct iso3166 lookup
  2. Fallback to common aliases (USA→UNITED STATES OF AMERICA, etc.)
  3. Preserve original country name if all lookups fail
- Add COUNTRY_NAME_ALIASES dict mapping common variations to official names
- Add comprehensive tests for country code preservation

This ensures country codes are never silently lost - they either resolve to valid alpha3 codes or preserve the original string for manual review.