### PR TITLE
feat: add workflow to sync new conference URLs to changedetection.io

### DIFF
--- a/.github/workflows/sync-changedetection.yaml
+++ b/.github/workflows/sync-changedetection.yaml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: sync-changedetection
   cancel-in-progress: false


### PR DESCRIPTION
Add GitHub Actions workflow that automatically adds new conference URLs to a self-hosted changedetection.io instance when they're added to the pythondeadlin.es repository.

Features:
- Triggers on push to main when _data/ changes
- Detects new URLs by comparing against last successful run
- Processes all URL fields: link, cfp_link, sponsor, finaid
- Smart year-templating for recurring conferences using Jinja2
- Automatic continent tagging based on lat/long coordinates
- Type tagging based on conference sub field (WEB, SCIPY, DATA)
- Uses search API to avoid duplicates
- Continues on individual URL failures
- Detailed summary in workflow output

https://claude.ai/code/session_01EsHkvaS2aCC16iWGzyuoYD