### PR TITLE
cfp: Swiss Python Summit 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,5 +1,23 @@
 ---
 
+- conference: Swiss Python Summit
+  year: 2026
+  link: https://python-summit.ch/
+  cfp_link: https://www.python-summit.ch/cfp/
+  cfp: '2026-05-31 23:59:00'
+  timezone: Europe/Zurich
+  place: Rapperswil, Switzerland
+  start: 2026-10-22
+  end: 2026-10-23
+  sponsor: https://www.python-summit.ch/sponsoring/
+  twitter: pythonsummit
+  sub: PY,DATA
+  note: 'Day 1: General Python Day; Day 2: Data Science Day'
+  location:
+  - title: Swiss Python Summit 2026
+    latitude: 47.223987
+    longitude: 8.8173
+
 - conference: Django Day Copenhagen
   year: 2026
   link: https://2026.djangoday.dk/


### PR DESCRIPTION
## Summary
- Add Swiss Python Summit 2026 (Oct 22-23, Rapperswil, Switzerland)
- CFP deadline: May 31, 2026
- Two-day event: General Python Day + Data Science Day

## Details
- Website: https://python-summit.ch/
- CFP: https://www.python-summit.ch/cfp/
- Sponsoring: https://www.python-summit.ch/sponsoring/