### PR TITLE
fix: ensure footer renders on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: home
+include_footer: true
 ---
 
 <div id="confs">


### PR DESCRIPTION
Set include_footer directly in index.html front matter instead of
relying on the home layout's front matter to cascade through the
jekyll-multiple-languages-plugin.