### PR TITLE
Always display footer and sneks on all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,10 +45,7 @@
       {% endfor %}
     {% endif %}
 
-    {% if page.include_footer %}
-      <footer>{% include_cached footer.html %}</footer>
-    {% else %}
-      {% include sneks.html %}
-    {% endif %}
+    <footer>{% include_cached footer.html %}</footer>
+    {% include sneks.html %}
   </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-include_footer: true
 ---
 
 {% capture fp_title %}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 show_masthead: true
-include_footer: true
 ---
 
 {% capture search_title %}{% t titles.search %}{% endcapture %}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: home
-include_footer: true
 ---
 
 <div id="confs">


### PR DESCRIPTION
## Summary
Removed conditional footer rendering logic to ensure the footer and sneks are displayed on all pages consistently.

## Changes
- Removed the `include_footer` conditional check from `_layouts/default.html` that previously controlled whether to show the footer or sneks
- Now both `footer.html` and `sneks.html` are always included on every page
- Removed the `include_footer: true` front matter from:
  - `_layouts/home.html`
  - `_layouts/search.html`
  - `index.html`

## Implementation Details
Previously, pages could control footer visibility through the `include_footer` front matter variable. This change simplifies the layout by removing that conditional logic and ensuring consistent footer/sneks display across the entire site. The footer and sneks components are now unconditionally rendered in the default layout.

https://claude.ai/code/session_01C51cqWMT6tmAKnjJDWB4H9