### PR TITLE
Update PyCon Ireland 2026 CfP deadline to 31 July

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -98,7 +98,7 @@
   year: 2026
   link: https://2026.pycon.ie/
   cfp_link: https://sessionize.com/pycon-ireland-2026/
-  cfp: '2026-08-30 23:59:00'
+  cfp: '2026-07-31 23:59:00'
   place: Dublin, Ireland
   start: 2026-10-17
   end: 2026-10-17


### PR DESCRIPTION
The PyCon Ireland 2026 CfP deadline was moved forward from 30 August to 31 July 2026 per the official announcement on 2026.pycon.ie.