### PR TITLE
fix(ci): stop all-contributors bot from stripping contributions

### DIFF
--- a/.github/workflows/pr-sort.yml
+++ b/.github/workflows/pr-sort.yml
@@ -84,10 +84,12 @@ jobs:
         # This check avoids a bug in all-contributors-cli (issue #371) where
         # adding an existing contribution type replaces all existing contributions
         if [[ -n "${{ steps.vars.outputs.contributor }}" ]]; then
-          pixi run install
-          pixi run add ${{ steps.vars.outputs.contributor }} conference
           CONTRIBUTOR="${{ steps.vars.outputs.contributor }}"
-          # Check if contributor already has "conference" contribution (the overlap triggers the bug)
+          # Check if contributor already has "conference" contribution (the overlap triggers the bug).
+          # IMPORTANT: there must be NO unconditional `all-contributors add` before this guard.
+          # all-contributors-cli replaces a contributor's whole contributions array when re-adding an
+          # existing type, so re-adding "conference" to someone who already has it strips their other
+          # contributions. The guard below is the ONLY add path: skip when "conference" is already present.
           if ! jq -e --arg login "$CONTRIBUTOR" '.contributors[] | select(.login == $login) | .contributions | index("conference")' .all-contributorsrc > /dev/null 2>&1; then
             echo "Adding conference contribution for: $CONTRIBUTOR"
             pixi run install


### PR DESCRIPTION
## Problem

The `pr-sort.yml` workflow has been opening PRs that **strip existing contributors down to a single `conference` contribution** (e.g. @JesperDramsch went from 17 contribution types to just `["conference"]` in `.all-contributorsrc`, `README.md` and `CONTRIBUTING.md`). This produced the bad PRs #371 and #379 (now closed).

## Root cause

The "Create branch and make changes" step ran an **unconditional** `all-contributors add <user> conference` *before* the jq guard that was added to prevent exactly this:

```bash
if [[ -n "...contributor" ]]; then
  pixi run install
  pixi run add <contributor> conference   # ← unconditional, runs every time
  CONTRIBUTOR=...
  if ! jq -e '... index("conference")' .all-contributorsrc; then   # ← guard
    pixi run add "$CONTRIBUTOR" conference
  else
    echo "...skipping..."
  fi
fi
```

`all-contributors-cli` **replaces** a contributor's entire `contributions` array when re-adding a type they already have. So the unconditional call collapsed the array on every run; the guard then read the *already-stripped* file, saw `conference` present, and skipped the second add — silently defeating the fix.

## Fix

Remove the unconditional add. The jq guard is now the only add path: it skips contributors who already have `conference` and adds only genuinely new contributors. The guard logic itself was verified correct (jq `index` returns `0`/truthy for existing, exits non-zero for new).

No behaviour change for new contributors; existing contributors are no longer corrupted.

## Notes
- Also affects the `workflow_dispatch` manual path (same code), so this one change covers both triggers.
- Optional follow-up (not in this PR): replace the pattern-based bot deny-list in the job `if:` with `github.event.pull_request.user.type == 'User'` for a more robust bot check.