### PR TITLE
Add PyCon South Africa 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,5 +1,24 @@
 ---
 
+- conference: PyCon South Africa
+  alt_name: PyCon ZA
+  year: 2026
+  link: https://za.pycon.org/
+  cfp_link: https://za.pycon.org/pages/speaking/how_to_apply/
+  cfp: '2026-08-14 23:59:00'
+  tutorial_deadline: '2026-08-14 23:59:00'
+  timezone: Africa/Johannesburg
+  place: Rondebosch, South Africa
+  start: 2026-10-14
+  end: 2026-10-18
+  twitter: PyConZA
+  mastodon: https://fosstodon.org/@PyConZA
+  sub: PY
+  location:
+  - title: PyCon South Africa 2026
+    latitude: -33.959834
+    longitude: 18.473872
+
 - conference: PyCon Wroclaw
   year: 2026
   link: https://www.pyconwroclaw.com/


### PR DESCRIPTION
Add details for the forthcoming PyConZA 2026 in Rondebosch.