### PR TITLE
PyCon Estonia 2026 has been cancelled

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -640,21 +640,6 @@
     latitude: 45.3349238
     longitude: 14.3067834
 
-- conference: PyCon Estonia
-  alt_name: PyCon EE
-  year: 2026
-  link: https://pycon.ee/
-  cfp_link: https://docs.google.com/forms/d/e/1FAIpQLSewbFKG6BEsGXR9ilgsW1wqfmzRR0Pf9XDO5WXTFhrcgrrN3g/viewform
-  cfp: '2026-02-28 23:59:00'
-  place: Tallinn, Estonia
-  start: 2026-10-08
-  end: 2026-10-09
-  sub: PY
-  location:
-  - title: PyCon Estonia 2026
-    latitude: 59.4372155
-    longitude: 24.7453688
-
 - conference: SciPy US
   alt_name: SciPy
   year: 2026


### PR DESCRIPTION
PyCon Estonia 2026 has been cancelled:

"We are extremely sorry to inform you that PyCon Estonia 2026 is cancelled, but we will return in 2027! Details to be disclosed soon."

https://pycon.ee/

They mention 1 September for 2027, but it's TBD, so perhaps it's a little early to add that. 