### PR TITLE
Add 2 new CfP/edition entries (cfp-scout 2026-08-08)

### DIFF
--- a/_data/archive.yml
+++ b/_data/archive.yml
@@ -96,6 +96,35 @@
     latitude: 52.2319581
     longitude: 21.0067249
 
+- conference: PyGrunn
+  year: 2026
+  link: https://pygrunn.org/
+  cfp_link: https://forms.gle/5qAYUczPptmGVCY58
+  cfp: TBA
+  place: Groningen, Netherlands
+  start: 2026-05-08
+  end: 2026-05-08
+  sub: PY
+  location:
+  - title: PyGrunn 2026
+    latitude: 53.2190652
+    longitude: 6.5680077
+
+- conference: Python Sul
+  alt_name: Python Sul (Brazil)
+  year: 2026
+  link: https://sul.python.org.br/
+  cfp: TBA
+  timezone: America/Sao_Paulo
+  place: Londrina, Brazil
+  start: 2026-05-01
+  end: 2026-05-03
+  sub: PY
+  location:
+  - title: Python Sul 2026
+    latitude: -23.4761271
+    longitude: -51.1179013
+
 - conference: North Bay Python
   year: 2026
   link: https://northbaypython.org/


### PR DESCRIPTION
## CfP Scout — 2026-08-08

Checked 10 stale series (rotation index 50/85, per `day-of-year mod count`) for new editions/CfPs. 2 confirmed editions found; both already have `cfp: TBA` since no submission deadline is published on the official sites.

**Note:** both PyGrunn 2026 (May 8) and Python Sul 2026 (May 1-3) already occurred before today's date, so `sort_yaml.py` correctly filed them into `_data/archive.yml` rather than the live `conferences.yml`. There's no countdown value for users, but backfilling them updates each series' recorded `latest_year` to 2026, so the next cfp-scout run looks for a 2027 edition instead of re-flagging these as stale candidates.

| Series | Year | CfP deadline | Evidence URL |
|---|---|---|---|
| PyGrunn | 2026 | TBA (RFP form open, no deadline published) | https://pygrunn.org/ |
| Python Sul | 2026 | TBA (talk submission link present, no deadline published) | https://sul.python.org.br/ |

<details>
<summary>Other checked series (8) — no action taken</summary>

| Series | Classification | Notes / Evidence URL |
|---|---|---|
| PyData Seattle | NO_NEWS | No 2026 edition listed; https://pydata.org/seattle2025/, https://pydata.org/ |
| PyData Tel Aviv | NO_NEWS | No 2026 edition listed; https://pydata.org/telaviv2025/ |
| PyData Vermont | NO_NEWS | Only mention found (official X account) is for the already-archived 2025 edition (Oct 21-22, 2025); https://pydata.org/vermont2025/ |
| PyData Virginia | NO_NEWS | No 2026 edition listed; https://pydata.org/virginia2025/ |
| PyHEP.dev | NO_NEWS | Page only covers the 2025 workshop; https://indico.cern.ch/event/1515852/ |
| PyLadiesCon | NO_NEWS | Page only covers the 2025 (Dec 5-7) edition; https://2025.conference.pyladies.com/en/ |
| Pytorch Day | NO_NEWS | Only PyTorch Day France 2025 (passed); https://events.linuxfoundation.org/pytorch-day-france/ |
| Wagtail Space | NO_NEWS | Page only covers the 2025 (Oct 8-10) edition; https://wagtail.org/wagtail-space-2025/ |

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_011pCubt8A3pmjAV8aFXwJER)_