### PR TITLE
Add 4 new CfP/edition entries (cfp-scout 2026-08-15)

### DIFF
--- a/_data/archive.yml
+++ b/_data/archive.yml
@@ -365,6 +365,19 @@
     latitude: -22.611456150000002
     longitude: 17.05860104184979
 
+- conference: Pytorch Day
+  year: 2026
+  link: https://events.linuxfoundation.org/pytorch-day-india/
+  cfp: TBA
+  place: Bengaluru, India
+  start: 2026-02-07
+  end: 2026-02-07
+  sub: DATA,DAY
+  location:
+  - title: Pytorch Day 2026
+    latitude: 12.9767936
+    longitude: 77.590082
+
 - conference: FOSDEM
   year: 2026
   link: https://fosdem.org/2026/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -48,6 +48,17 @@
     latitude: -22.5597
     longitude: 17.0832
 
+- conference: Wagtail Space
+  year: 2026
+  link: https://wagtail.org/wagtail-space-2026/
+  cfp_link: https://pretalx.com/wagtail-space-2026/cfp
+  cfp: '2026-09-11 23:59:00'
+  timezone: UTC
+  place: Online
+  start: 2026-11-18
+  end: 2026-11-20
+  sub: WEB
+
 - conference: PyCon Netherlands
   alt_name: PyCon NL
   year: 2026
@@ -81,6 +92,21 @@
   - title: Django Day Copenhagen 2026
     latitude: 50.0478
     longitude: 12.5604627
+
+- conference: PyHEP.dev
+  alt_name: PyHEP
+  year: 2026
+  link: https://indico.nikhef.nl/event/7873/
+  cfp: '2026-08-14 23:59:00'
+  timezone: Europe/Amsterdam
+  place: Amsterdam, Netherlands
+  start: 2026-09-07
+  end: 2026-09-09
+  sub: SCIPY
+  location:
+  - title: PyHEP.dev 2026
+    latitude: 52.4111289
+    longitude: 4.877231604293446
 
 - conference: PyCon South Africa
   alt_name: PyCon ZA
@@ -783,6 +809,15 @@
 - conference: XtremePython
   year: 2026
   link: https://xtremepython.dev/
+  cfp: TBA
+  place: Online
+  start: 2026-11-17
+  end: 2026-11-17
+  sub: PY
+
+- conference: Xtreme Python
+  year: 2026
+  link: https://xtremepython.dev/2026/
   cfp: TBA
   place: Online
   start: 2026-11-17

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -832,15 +832,6 @@
   end: 2026-11-17
   sub: PY
 
-- conference: Xtreme Python
-  year: 2026
-  link: https://xtremepython.dev/2026/
-  cfp: TBA
-  place: Online
-  start: 2026-11-17
-  end: 2026-11-17
-  sub: PY
-
 - conference: FastAPI Conference
   year: 2026
   link: https://fastapiconf.com/


### PR DESCRIPTION
## CfP Scout — 2026-08-15

Scouted 10 conference series with no upcoming entry in `_data/conferences.yml` (rotation index `227 mod 87 = 53` for 2026-08-15). 4 new editions found and added.

| Series | Year | CfP deadline | Evidence URL |
|---|---|---|---|
| PyHEP.dev | 2026 | 2026-08-14 23:59 Europe/Amsterdam (already elapsed as of run date) | https://indico.nikhef.nl/event/7873/ |
| Pytorch Day | 2026 | TBA (India edition, already occurred Feb 7 2026; no CfP deadline found) | https://events.linuxfoundation.org/pytorch-day-india/ |
| Wagtail Space | 2026 | 2026-09-11 23:59 UTC | https://pretalx.com/wagtail-space-2026/cfp |
| Xtreme Python | 2026 | TBA (no CfP found on official site) | https://xtremepython.dev/2026/ |

**Notes:**
- **PyHEP.dev 2026** (Amsterdam, Sept 7-9) is distinct from the existing "PyHEP" series (Geneva, also Sept 7-9 2026) already tracked — these are separate events (developer workshop vs. main conference), consistent with how prior years are recorded in `_data/archive.yml`.
- **Wagtail Space 2026** date conflict: the event's own landing page states "18-20 November" while the official blog post states talks run "November 18-19". Recorded `start`/`end` as 2026-11-18 to 2026-11-20 (trusting the primary event page).
- **Pytorch Day India 2026** already occurred before today's run date, so `sort_yaml.py` correctly filed it into `_data/archive.yml`. Backfilling it updates the series' recorded `latest_year` to 2026, so the next cfp-scout run looks for a 2027 edition instead of re-flagging this series as stale.

<details>
<summary>Other checked series (6) — no action taken</summary>

| Series | Classification | Notes / Evidence URL |
|---|---|---|
| PyData Paris | NO_NEWS | Page only covers 2025 edition (Sept 30 - Oct 1, 2025); https://pydata.org/paris2025 |
| PyData Seattle | NO_NEWS | 2025 page 404s; no 2026 edition on https://pydata.org/upcoming-events/ |
| PyData Tel Aviv | NO_NEWS | No 2026 edition found; https://pydata.org/telaviv2025/ |
| PyData Vermont | NO_NEWS | No 2026 edition found; https://pydata.org/vermont2025/ |
| PyData Virginia | NO_NEWS | No 2026 edition found; https://pydata.org/virginia2025/ |
| PyLadiesCon | NO_NEWS | Page only covers 2025 (Dec 5-7) edition; no 2026 announcement found; https://2025.conference.pyladies.com/en/ |

</details>

## Validation

- `python utils/sort_yaml.py --skip_links` ran clean: 1195 conferences passed validation, no errors.
- `git diff --stat`: only `_data/conferences.yml` and `_data/archive.yml` changed.
- No new duplicate series+year pairs introduced (pre-existing unrelated dupes: PyCon China, RuPy).

---
_Generated by [Claude Code](https://claude.ai/code/session_012JHYpZjUgyAi6LFrsPsQDv)_