### PR TITLE
Add 2 new CfP/edition entries (cfp-scout 2026-08-22)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -833,6 +833,20 @@
   end: 2026-11-17
   sub: PY
 
+- conference: PyCon Tanzania
+  alt_name: Python Tanzania Conference
+  year: 2026
+  link: https://pycon.or.tz/
+  cfp: TBA
+  place: Dar Es Salaam, Tanzania
+  start: 2026-11-14
+  end: 2026-11-16
+  sub: PY
+  location:
+  - title: PyCon Tanzania 2026
+    latitude: -6.8160837
+    longitude: 39.2803583
+
 - conference: FastAPI Conference
   year: 2026
   link: https://fastapiconf.com/
@@ -845,6 +859,19 @@
   - title: FastAPI Conference 2026
     latitude: 52.3730796
     longitude: 4.8924534
+
+- conference: PyCon Panamá
+  year: 2026
+  link: https://pycon.pa/2026/
+  cfp: TBA
+  place: Panama City, Panamá
+  start: 2026-10-22
+  end: 2026-10-23
+  sub: PY
+  location:
+  - title: PyCon Panamá 2026
+    latitude: 8.9714493
+    longitude: -79.5341802
 
 - conference: PyCon Estonia
   alt_name: PyCon EE


### PR DESCRIPTION
Scouted 10 stale conference series (rotation index 64/85 for day-of-year 234) for new editions. Found 2 confirmed new editions (no CfP dates published yet, recorded as `TBA`).

| Series | Year | CfP deadline | Evidence URL |
|---|---|---|---|
| PyCon Panamá | 2026 | TBA | https://pycon.pa/2026/ (Oct 22–23, 2026, virtual day + in-person at Universidad del Istmo, Metromall campus; speaker submission page live, no deadline listed) |
| PyCon Tanzania | 2026 | TBA | https://pycon.or.tz/ (Nov 14–16, 2026, Dar es Salaam, described as the "5th Edition"; no CfP page live yet — `/speak/` 404s) |

<details>
<summary>Other checked series (8) — no changes</summary>

| Series | Classification | Notes |
|---|---|---|
| PyCon KyuShu | NO_NEWS | `kyushu.pycon.jp/` root is empty; `/2025/` only has a stale "planning autumn 2025" organizer-recruitment note for Miyazaki, no confirmed dates; `/2026/` 404s. |
| PyCon MEA | NO_NEWS | Official site `globaldevslam.com` returns HTTP 403. Two searches found only a vague link to the Global DevSlam / GITEX Global 2026 ecosystem (Dubai, Dec 7–11, 2026) but no PyCon MEA–specific confirmation or dates. |
| PyCon Mini Tokai | NO_NEWS | 2025 edition (Nov 8, 2025) already happened; `/2026/` 404s — next edition not yet announced. |
| PyCon Niger | DEAD_SITE | `ne.pycon.org` no longer resolves (DNS failure). Successor site `pythonniger.org` only lists PyCon Niger 2024 as past; no 2025/2026 edition announced (other 2026 events listed, none are PyCon Niger). Legacy suspect. |
| PyCon Pakistan | NO_NEWS | `pycon.pk/` still only shows the 2024 edition; `/2025/` and `/2026/` both 404. |
| PyCon Philippines | NO_NEWS | Found "PythonAsia 2026 Philippines", but its dates (Mar 21–23, 2026) are already in the past relative to today; no newer edition found. |
| PyCon Slovakia | NO_NEWS | `2024.pycon.sk` shows only the 2024 edition; `2026.pycon.sk` does not resolve; search found nothing about a 2026 edition. |
| PyCon Zimbabwe | DEAD_SITE | `zw.pycon.org` returns HTTP 503; search only surfaces the past 2024 edition (Nov 1–2, 2024, Harare) and unrelated PyCon Africa events. Legacy suspect. |

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbM5h416v2NsgchxfsbKHb)_