### PR TITLE
Add 2 new CfP/edition entries (cfp-scout 2026-08-29)

### DIFF
--- a/_data/archive.yml
+++ b/_data/archive.yml
@@ -1,5 +1,45 @@
 ---
 
+- conference: SciPy US
+  alt_name: SciPy
+  year: 2026
+  link: https://www.scipy2026.scipy.org/
+  cfp_link: https://pretalx.com/scipy-2026/cfp
+  cfp: '2026-02-25 15:20:00'
+  cfp_ext: '2026-03-04 23:59:00'
+  tutorial_deadline: '2026-03-04 23:59:00'
+  timezone: America/Chicago
+  place: Minneapolis, USA
+  start: 2026-07-13
+  end: 2026-07-19
+  sponsor: https://www.scipy2026.scipy.org/s/SciPy26-SponsorProspectus-wn87.pdf
+  finaid: https://docs.google.com/forms/d/e/1FAIpQLSdVD-AHPDcoVF4FPKdaWDTS9NyZtGym0KxoKf6AnWxv0MIiWg/viewform
+  mastodon: https://mastodon.social/@SciPyConf
+  sub: SCIPY
+  location:
+  - title: SciPy US 2026
+    latitude: 44.9772995
+    longitude: -93.2654692
+
+- conference: EuroPython
+  year: 2026
+  link: https://ep2026.europython.eu/
+  cfp_link: https://ep2026.europython.eu/cfp
+  cfp: '2026-02-15 23:55:00'
+  tutorial_deadline: '2026-02-15 23:59:00'
+  place: Kraków, Poland
+  start: 2026-07-13
+  end: 2026-07-19
+  sponsor: https://ep2026.europython.eu/sponsors
+  finaid: https://ep2026.europython.eu/finaid
+  twitter: EuroPython
+  mastodon: https://fosstodon.org/@europython
+  sub: PY
+  location:
+  - title: EuroPython 2026
+    latitude: 50.0478
+    longitude: 19.9314
+
 - conference: Python Norte
   year: 2026
   link: https://pythonnorte.org/
@@ -42,6 +82,21 @@
     latitude: 1.2899175
     longitude: 103.8519072
 
+- conference: Wagtail Space Netherlands
+  year: 2026
+  link: https://nl.wagtail.space/
+  cfp_link: https://nl.wagtail.space/call-for-participation
+  cfp: '2026-05-29 23:59:00'
+  timezone: Europe/Amsterdam
+  place: Rotterdam, Netherlands
+  start: 2026-06-12
+  end: 2026-06-12
+  sub: WEB
+  location:
+  - title: Wagtail Space Netherlands 2026
+    latitude: 51.9244424
+    longitude: 4.47775
+
 - conference: GeoPython
   year: 2026
   link: https://2026.geopython.net/
@@ -59,6 +114,19 @@
   - title: GeoPython 2026
     latitude: 47.3615882
     longitude: 7.354445
+
+- conference: PyDay Valparaiso
+  year: 2026
+  link: https://www.pyday.cl/valparaiso.html
+  cfp: TBA
+  place: Valparaiso, Chile
+  start: 2026-06-05
+  end: 2026-06-05
+  sub: DAY
+  location:
+  - title: PyDay Valparaiso 2026
+    latitude: -32.5976089
+    longitude: -70.8529753
 
 - conference: PyData London
   year: 2026

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -14,6 +14,25 @@
     latitude: 54.6870458
     longitude: 25.2829111
 
+- conference: SciPy India
+  year: 2026
+  link: https://scipy.in/2026/
+  cfp_link: https://cfp.scipy.in/scipy-india-2026/cfp
+  cfp: '2026-10-19 23:59:00'
+  timezone: Asia/Kolkata
+  place: Chennai, India
+  start: 2026-12-19
+  end: 2026-12-20
+  sponsor: https://scipy.in/2026/sponsor.html
+  mastodon: https://fosstodon.org/@scipyindia
+  bluesky: https://bsky.app/profile/scipy.in
+  youtube: https://www.youtube.com/@scipy-india
+  sub: SCIPY
+  location:
+  - title: SciPy India 2026
+    latitude: 12.9917014
+    longitude: 80.2295271
+
 - conference: PyCon Wroclaw
   year: 2026
   link: https://www.pyconwroclaw.com/
@@ -669,46 +688,6 @@
     latitude: 41.8755616
     longitude: -87.6244212
 
-- conference: SciPy US
-  alt_name: SciPy
-  year: 2026
-  link: https://www.scipy2026.scipy.org/
-  cfp_link: https://pretalx.com/scipy-2026/cfp
-  cfp: '2026-02-25 15:20:00'
-  cfp_ext: '2026-03-04 23:59:00'
-  tutorial_deadline: '2026-03-04 23:59:00'
-  timezone: America/Chicago
-  place: Minneapolis, USA
-  start: 2026-07-13
-  end: 2026-07-19
-  sponsor: https://www.scipy2026.scipy.org/s/SciPy26-SponsorProspectus-wn87.pdf
-  finaid: https://docs.google.com/forms/d/e/1FAIpQLSdVD-AHPDcoVF4FPKdaWDTS9NyZtGym0KxoKf6AnWxv0MIiWg/viewform
-  mastodon: https://mastodon.social/@SciPyConf
-  sub: SCIPY
-  location:
-  - title: SciPy US 2026
-    latitude: 44.9772995
-    longitude: -93.2654692
-
-- conference: EuroPython
-  year: 2026
-  link: https://ep2026.europython.eu/
-  cfp_link: https://ep2026.europython.eu/cfp
-  cfp: '2026-02-15 23:55:00'
-  tutorial_deadline: '2026-02-15 23:59:00'
-  place: Kraków, Poland
-  start: 2026-07-13
-  end: 2026-07-19
-  sponsor: https://ep2026.europython.eu/sponsors
-  finaid: https://ep2026.europython.eu/finaid
-  twitter: EuroPython
-  mastodon: https://fosstodon.org/@europython
-  sub: PY
-  location:
-  - title: EuroPython 2026
-    latitude: 50.0478
-    longitude: 19.9314
-
 - conference: PyCon Poland
   alt_name: PyCon PL
   year: 2026
@@ -792,25 +771,6 @@
   - title: PyCon Germany & PyData Conference 2027
     latitude: 49.4093582
     longitude: 8.694724
-
-- conference: SciPy India
-  year: 2026
-  link: https://scipy.in/2026/
-  cfp: '2026-10-19 23:59:00'
-  cfp_link: https://cfp.scipy.in/scipy-india-2026/cfp
-  timezone: Asia/Kolkata
-  place: Chennai, India
-  start: 2026-12-19
-  end: 2026-12-20
-  sponsor: https://scipy.in/2026/sponsor.html
-  mastodon: https://fosstodon.org/@scipyindia
-  bluesky: https://bsky.app/profile/scipy.in
-  youtube: https://www.youtube.com/@scipy-india
-  sub: SCIPY
-  location:
-  - title: SciPy India 2026
-    latitude: 12.9917014
-    longitude: 80.2295271
 
 - conference: Python E-Commerce Forum
   year: 2026


### PR DESCRIPTION
Scouted 10 stale conference series (rotation index 75, wrapping) for new editions and CfPs. Both new findings turned out to be editions that already took place earlier in 2026 (their dates are in the past relative to today, 2026-08-29), so `sort_yaml.py` correctly filed them straight into `_data/archive.yml` rather than the active list — they're added for record completeness.

| Series | Year | CfP deadline | Evidence URL |
|---|---|---|---|
| PyDay Valparaiso | 2026 | TBA (CfP closed by the time of this scout; no exact deadline published on the page) | https://www.pyday.cl/valparaiso/ |
| Wagtail Space Netherlands | 2026 | 2026-05-29 23:59 | https://nl.wagtail.space/call-for-participation |

<details>
<summary>Other series checked (no entry added)</summary>

| Series | Classification | Notes |
|---|---|---|
| PyDay Copiapó | NO_NEWS | `/copiapo.html` 404s; the parent site's 2026 listing (Valparaíso, Santiago, Rancagua) does not include Copiapó — likely dropped from this year's rotation. |
| Python Niger | DEAD_SITE | The tracked link was already an archived (web.archive.org) Facebook event page; no live site or newer info found via search. Legacy suspect. |
| Python Pizza Prague | NO_NEWS | Site still only shows the 2024 event; no 2026 edition or CfP announced. |
| Python fwdays | NO_NEWS | fwdays.com's 2026 events list has no Python/Data-Science-specific conference; only unrelated tracks (AI agents, Kubernetes, DevOps, etc.) and a generic "Fwdays Tech Summit" that isn't confirmed as the Python series. |
| Python in Education Day | DEAD_SITE | `scienceoxford.com/python-in-education-day/` 404s and the event is absent from the Science Oxford homepage. Legacy suspect. |
| Wagtail Space US | NO_NEWS | Site still shows the 2024 edition (Philadelphia); CfP closed, no 2026 edition announced. |
| DjangoCon Europe | NO_NEWS | Already fully recorded in `_data/archive.yml` (2026, Athens, Apr 15–19) from a prior scout run — not a new finding. |
| FOSDEM | NO_NEWS | Already recorded in `_data/archive.yml` (2026, Brussels, Jan 31 – Feb 1) from a prior scout run — not a new finding. |

</details>

Ran `python utils/sort_yaml.py --skip_links` after appending entries; validation passed clean, only `_data/conferences.yml` and `_data/archive.yml` changed, and no new duplicate series+year pairs were introduced (pre-existing PyCon China/RuPy duplicates are unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcUiYGWw87XuP4yg6aLVFs)_